### PR TITLE
Update minio-post-install-job.yaml

### DIFF
--- a/charts/datalab/templates/minio-post-install-job.yaml
+++ b/charts/datalab/templates/minio-post-install-job.yaml
@@ -46,4 +46,5 @@ spec:
       - name: configmap-volume
         configMap:
           defaultMode: 0700
-          name: policy-update-script-configmap
+          name: minio-post-install-policy-update-script-configmap
+    backoffLimit: 10


### PR DESCRIPTION
Fixed the configmap-volume mapping name with the actual script name. "minio-post-install-policy-update-script-configmap" instead of "policy-update-script-configmap"
Added a backoffLimit to wait for the keycloak's pod creation before Minio.